### PR TITLE
Fixed build, now it works on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "./node_modules/typescript/bin/tsc",
+    "build": "node ./node_modules/typescript/bin/tsc",
     "start": "NODE_ENV=production node dist/index.js"
   },
   "author": "",


### PR DESCRIPTION
By adding "node" in front of "./node_modules/typescript/bin/tsc" windows will now correctly run the command. 
I've also tested this on an ubuntu machine and it worked there.